### PR TITLE
Ask volunteers to register after they submit the form

### DIFF
--- a/web/templates/page/thank-you-problem.html.eex
+++ b/web/templates/page/thank-you-problem.html.eex
@@ -5,4 +5,27 @@
   to discuss details. If you have any questions in the meantime,
   <a href="/contact">send us an email.</a>
   </p>
+  <%= if is_nil(@current_user) do %>
+    <p>
+    To get one step ahead of the game, create an account so
+    you can hit the ground running when the project is ready to use your skills.
+    </p>
+    <hr />
+    <form method="POST" action="/register">
+      <input type="hidden" id="_csrf_token"  name="_csrf_token" value="<%= get_csrf_token() %>">
+      <div class="form-group">
+        <label for="email">Email address</label>
+        <input type="email" name="email" id="email" required class="form-control" <%= if @conn.assigns[:email] do %>value="<%= @conn.assigns[:email] %>"<% end %>>
+      </div>
+      <div class="form-group">
+        <label for="password">Password</label>
+        <input type="password" name="password" id="password" required class="form-control">
+      </div>
+      <div class="form-group">
+        <label for="password-confirm">Re-type password</label>
+        <input type="password" name="password-confirm" id="password-confirm" required class="form-control">
+      </div>
+      <input class="btn btn-primary" type="submit" value="Register">
+    </form>
+  <% end %>
 </div>

--- a/web/templates/session/register.html.eex
+++ b/web/templates/session/register.html.eex
@@ -5,7 +5,6 @@
   <% end %>
   <form method="POST" action="/register">
     <input type="hidden" id="_csrf_token"  name="_csrf_token" value="<%= get_csrf_token() %>">
-    <% IO.inspect @conn.assigns %>
     <div class="form-group">
       <label for="email">Email address</label>
       <input type="email" name="email" id="email" required class="form-control" <%= if @conn.assigns[:email] do %>value="<%= @conn.assigns[:email] %>"<% end %>>


### PR DESCRIPTION
Fixes #6 

When someone volunteers for a project, and they are not signed in. They will now see a registration form as well so they can sign up to help.

![image](https://cloud.githubusercontent.com/assets/645092/23879390/c0d74fc6-081a-11e7-8da2-23f2bfb0f9e4.png)
